### PR TITLE
silence "cannot be created: The file already exists" dns_warmer.sh

### DIFF
--- a/devops/dns_warmer.sh
+++ b/devops/dns_warmer.sh
@@ -5,6 +5,6 @@ echo $SCRIPTPATH
 cd $SCRIPTPATH
 
 
-mkdir $SCRIPTPATH/../logs/
+mkdir --parents $SCRIPTPATH/../logs/
 python3 -B ../dns_warmer.py > $SCRIPTPATH/../logs/dns_warmer.log 2>&1
  


### PR DESCRIPTION
stop complaining about existence of directory, if rerun from beginning of second execution. 